### PR TITLE
110 improve oauth config type

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,38 +103,34 @@ tokenCache.get('service-foo')
 });
 ```
 
-Where `OAuthConfig` is defined like:
+The `OAuthConfig` type is defined as union type:
 
 ```typescript
-type OAuthConfig = {
+type OAuthConfig =
+  ClientCredentialsGrantConfig   |
+  AuthorizationCodeGrantConfig   |
+  PasswordCredentialsGrantConfig |
+  RefreshGrantConfig;
+```
+
+As you can see there are four different config types defined, which can be used in any places where `OAuthConfig` is required:
+
+* ClientCredentialsGrantConfig
+* AuthorizationCodeGrantConfig
+* PasswordCredentialsGrantConfig
+* RefreshGrantConfig
+
+Each config type has common properties:
+
+```typescript
+type GrantConfigBase = {
   credentialsDir: string;
-  grantType: string;
   accessTokenEndpoint: string;
-  tokenInfoEndpoint?: string; // mandatory for TokenCache
-  scopes?: string[];
-  redirect_uri?: string; // (required with `AUTHORIZATION_CODE_GRANT`)
-  code?: string; // (required with `AUTHORIZATION_CODE_GRANT`)
-  redirectUri?: string;
-  refreshToken?: string;
-  queryParams?: {};
+  queryParams?: { [index: string]: string };
 };
 ```
 
-Valid `grantTypes`s are:
-* `'authorization_code'`
-* `'password'`
-* `'client_credentials'`
-* `'refresh_token'`
-
-You can also import the constants from the lib:
-```typescript
-import {
-  AUTHORIZATION_CODE_GRANT,
-  PASSWORD_CREDENTIALS_GRANT,
-  CLIENT_CREDENTIALS_GRANT,
-  REFRESH_TOKEN_GRANT
-} from 'authmosphere';
-```
+The constant grant types literals can be found in `OAuthGrandType`
 
 Optionally, you can pass a third parameter of type `TokenCacheConfig` to the `TokenCache` constructor to configure the cache behaviour.
 

--- a/integration-test/mock-tooling/index.ts
+++ b/integration-test/mock-tooling/index.ts
@@ -4,13 +4,15 @@ import * as chaiAsPromised from 'chai-as-promised';
 import {
   getTokenInfo,
   getAccessToken,
-  PASSWORD_CREDENTIALS_GRANT,
   mockTokeninfoEndpoint,
   mockAccessTokenEndpoint,
   cleanMock
 } from '../../src/index';
 
-import { Token } from '../../src/types';
+import {
+  Token,
+  OAuthGrantType
+} from '../../src/types';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -153,7 +155,7 @@ describe('mock tooling', () => {
         scopes: ['uid'],
         accessTokenEndpoint: accessTokenEndpoint,
         credentialsDir: 'integration-test/data/credentials',
-        grantType: PASSWORD_CREDENTIALS_GRANT
+        grantType: OAuthGrantType.PASSWORD_CREDENTIALS_GRANT
       };
       mockAccessTokenEndpoint({
         url: accessTokenEndpoint

--- a/integration-test/mock-tooling/index.ts
+++ b/integration-test/mock-tooling/index.ts
@@ -11,7 +11,8 @@ import {
 
 import {
   Token,
-  OAuthGrantType
+  OAuthGrantType,
+  PasswordCredentialsGrantConfig
 } from '../../src/types';
 
 chai.use(chaiAsPromised);
@@ -151,7 +152,7 @@ describe('mock tooling', () => {
     it('accessToken endpoint should return valid token', function () {
 
       // given
-      const options = {
+      const options: PasswordCredentialsGrantConfig = {
         scopes: ['uid'],
         accessTokenEndpoint: accessTokenEndpoint,
         credentialsDir: 'integration-test/data/credentials',

--- a/integration-test/oauth-tooling/getAccessToken.spec.ts
+++ b/integration-test/oauth-tooling/getAccessToken.spec.ts
@@ -8,7 +8,11 @@ import {
 } from '../../src/index';
 
 import {
-  OAuthGrantType
+  OAuthGrantType,
+  PasswordCredentialsGrantConfig,
+  ClientCredentialsGrantConfig,
+  AuthorizationCodeGrantConfig,
+  RefreshGrantConfig
 } from '../../src/types';
 
 chai.use(chaiAsPromised);
@@ -67,7 +71,7 @@ describe('getAccessToken', () => {
       credentialsDir: 'integration-test/data/credentials',
       grantType: 'INVALID',
       queryParams: { realm: '/services' }
-    });
+    } as any); // deactivate type system in order to test runtime behavior
 
     // then
     return expect(promise).to.be.rejected;
@@ -75,7 +79,7 @@ describe('getAccessToken', () => {
 
   describe('password credentials grant', () => {
 
-    const passwordCredentialsOAuthOptions = {
+    const passwordCredentialsOAuthOptions: PasswordCredentialsGrantConfig = {
       scopes: ['campaign.edit_all', 'campaign.read_all'],
       accessTokenEndpoint: `${oAuthServerHost}${accessTokenEndpoint}`,
       credentialsDir: 'integration-test/data/credentials',
@@ -137,7 +141,7 @@ describe('getAccessToken', () => {
 
   describe('client credentials grant', () => {
 
-    const clientCredentialsOAuthOptions = {
+    const clientCredentialsOAuthOptions: ClientCredentialsGrantConfig = {
       scopes: ['campaign.edit_all', 'campaign.read_all'],
       accessTokenEndpoint: `${oAuthServerHost}${accessTokenEndpoint}`,
       credentialsDir: 'integration-test/data/credentials',
@@ -200,7 +204,7 @@ describe('getAccessToken', () => {
     const validCode = '1234';
     const validRedirectUri = 'http://redirect.com';
 
-    const authCodeOAuthOptions = {
+    const authCodeOAuthOptions: AuthorizationCodeGrantConfig = {
       scopes: ['campaign.edit_all', 'campaign.read_all'],
       accessTokenEndpoint: `${oAuthServerHost}${accessTokenEndpoint}`,
       credentialsDir: 'integration-test/data/credentials',
@@ -266,7 +270,7 @@ describe('getAccessToken', () => {
 
     const validRefreshToken = 'refresh';
 
-    const clientCredentialsOAuthOptions = {
+    const clientCredentialsOAuthOptions: RefreshGrantConfig = {
       scopes: ['campaign.edit_all', 'campaign.read_all'],
       accessTokenEndpoint: `${oAuthServerHost}${accessTokenEndpoint}`,
       credentialsDir: 'integration-test/data/credentials',

--- a/integration-test/oauth-tooling/getAccessToken.spec.ts
+++ b/integration-test/oauth-tooling/getAccessToken.spec.ts
@@ -4,12 +4,12 @@ import * as HttpStatus from 'http-status';
 import * as nock from 'nock';
 
 import {
-  getAccessToken,
-  PASSWORD_CREDENTIALS_GRANT,
-  AUTHORIZATION_CODE_GRANT,
-  REFRESH_TOKEN_GRANT,
-  CLIENT_CREDENTIALS_GRANT
+  getAccessToken
 } from '../../src/index';
+
+import {
+  OAuthGrantType
+} from '../../src/types';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -46,7 +46,7 @@ describe('getAccessToken', () => {
       scopes: ['campaign.edit_all', 'campaign.read_all'],
       accessTokenEndpoint: `${oAuthServerHost}${accessTokenEndpoint}`,
       credentialsDir: 'integration-test/data/credentials',
-      grantType: PASSWORD_CREDENTIALS_GRANT,
+      grantType: OAuthGrantType.PASSWORD_CREDENTIALS_GRANT,
       queryParams: { realm: '/services' }
     });
 
@@ -79,7 +79,7 @@ describe('getAccessToken', () => {
       scopes: ['campaign.edit_all', 'campaign.read_all'],
       accessTokenEndpoint: `${oAuthServerHost}${accessTokenEndpoint}`,
       credentialsDir: 'integration-test/data/credentials',
-      grantType: PASSWORD_CREDENTIALS_GRANT
+      grantType: OAuthGrantType.PASSWORD_CREDENTIALS_GRANT
     };
 
     it('should resolve with access token if valid', () => {
@@ -89,7 +89,7 @@ describe('getAccessToken', () => {
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .matchHeader('Authorization', `Basic ${clientSecret}`)
         .post(accessTokenEndpoint, {
-          grant_type: PASSWORD_CREDENTIALS_GRANT,
+          grant_type: OAuthGrantType.PASSWORD_CREDENTIALS_GRANT,
           username: validUserName,
           password: validUserPassword,
           scope: 'campaign.edit_all campaign.read_all'
@@ -141,7 +141,7 @@ describe('getAccessToken', () => {
       scopes: ['campaign.edit_all', 'campaign.read_all'],
       accessTokenEndpoint: `${oAuthServerHost}${accessTokenEndpoint}`,
       credentialsDir: 'integration-test/data/credentials',
-      grantType: CLIENT_CREDENTIALS_GRANT
+      grantType: OAuthGrantType.CLIENT_CREDENTIALS_GRANT
     };
 
     it('should resolve with access token if valid', () => {
@@ -151,7 +151,7 @@ describe('getAccessToken', () => {
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .matchHeader('Authorization', `Basic ${clientSecret}`)
         .post(accessTokenEndpoint, {
-          grant_type: CLIENT_CREDENTIALS_GRANT,
+          grant_type: OAuthGrantType.CLIENT_CREDENTIALS_GRANT,
           scope: 'campaign.edit_all campaign.read_all'
         })
         .reply(HttpStatus.OK, { access_token: accessToken });
@@ -204,7 +204,7 @@ describe('getAccessToken', () => {
       scopes: ['campaign.edit_all', 'campaign.read_all'],
       accessTokenEndpoint: `${oAuthServerHost}${accessTokenEndpoint}`,
       credentialsDir: 'integration-test/data/credentials',
-      grantType: AUTHORIZATION_CODE_GRANT,
+      grantType: OAuthGrantType.AUTHORIZATION_CODE_GRANT,
       code: validCode,
       redirectUri: validRedirectUri
     };
@@ -216,7 +216,7 @@ describe('getAccessToken', () => {
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .matchHeader('Authorization', `Basic ${clientSecret}`)
         .post(accessTokenEndpoint, {
-          grant_type: AUTHORIZATION_CODE_GRANT,
+          grant_type: OAuthGrantType.AUTHORIZATION_CODE_GRANT,
           code: validCode,
           redirect_uri: validRedirectUri,
           scope: 'campaign.edit_all campaign.read_all'
@@ -270,7 +270,7 @@ describe('getAccessToken', () => {
       scopes: ['campaign.edit_all', 'campaign.read_all'],
       accessTokenEndpoint: `${oAuthServerHost}${accessTokenEndpoint}`,
       credentialsDir: 'integration-test/data/credentials',
-      grantType: REFRESH_TOKEN_GRANT,
+      grantType: OAuthGrantType.REFRESH_TOKEN_GRANT,
       refreshToken: validRefreshToken
     };
 
@@ -281,7 +281,7 @@ describe('getAccessToken', () => {
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .matchHeader('Authorization', `Basic ${clientSecret}`)
         .post(accessTokenEndpoint, {
-          grant_type: REFRESH_TOKEN_GRANT,
+          grant_type: OAuthGrantType.REFRESH_TOKEN_GRANT,
           scope: 'campaign.edit_all campaign.read_all',
           refresh_token: validRefreshToken
         })

--- a/integration-test/oauth-tooling/middlewares.spec.ts
+++ b/integration-test/oauth-tooling/middlewares.spec.ts
@@ -7,9 +7,12 @@ import fetch from 'node-fetch';
 
 import {
   handleOAuthRequestMiddleware,
-  requireScopesMiddleware,
-  PASSWORD_CREDENTIALS_GRANT
+  requireScopesMiddleware
 } from '../../src/index';
+
+import {
+  OAuthGrantType
+} from '../../src/types';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -67,7 +70,7 @@ describe('middlewares', () => {
             'campaign.editall',
             'campaign.readall'
           ],
-          'grant_type': PASSWORD_CREDENTIALS_GRANT,
+          'grant_type': OAuthGrantType.PASSWORD_CREDENTIALS_GRANT,
           'uid': 'services',
           'access_token': '4b70510f-be1d-4f0f-b4cb-edbca2c79d41'
         });
@@ -94,7 +97,7 @@ describe('middlewares', () => {
           'scope': [
             'campaign.readall'
           ],
-          'grant_type': PASSWORD_CREDENTIALS_GRANT,
+          'grant_type': OAuthGrantType.PASSWORD_CREDENTIALS_GRANT,
           'uid': 'services',
           'access_token': '4b70510f-be1d-4f0f-b4cb-edbca2c79d41'
         });
@@ -119,7 +122,7 @@ describe('middlewares', () => {
           'token_type': 'Bearer',
           'realm': 'employees',
           'scope': '',
-          'grant_type': PASSWORD_CREDENTIALS_GRANT,
+          'grant_type': OAuthGrantType.PASSWORD_CREDENTIALS_GRANT,
           'uid': 'services',
           'access_token': '4b70510f-be1d-4f0f-b4cb-edbca2c79d41'
         });

--- a/integration-test/oauth-tooling/tokenCache.spec.ts
+++ b/integration-test/oauth-tooling/tokenCache.spec.ts
@@ -6,9 +6,12 @@ import * as lolex from 'lolex';
 
 import {
   TokenCache,
-  defaultTokenCacheConfig,
-  PASSWORD_CREDENTIALS_GRANT
+  defaultTokenCacheConfig
 } from '../../src/index';
+
+import {
+  OAuthGrantType
+} from '../../src/types';
 
 import { TokenCacheOAuthConfig } from '../../src/types/OAuthConfig';
 
@@ -25,7 +28,7 @@ describe('tokenCache', () => {
       expires_in: 3600,
       token_type: 'Bearer',
       scope: ['nucleus.write', 'nucleus.read'],
-      grant_type: PASSWORD_CREDENTIALS_GRANT,
+      grant_type: OAuthGrantType.PASSWORD_CREDENTIALS_GRANT,
       uid: 'uid',
       access_token: defaultAccessTokenValue
     };
@@ -35,7 +38,7 @@ describe('tokenCache', () => {
       accessTokenEndpoint: oauthHost + '/access_token',
       tokenInfoEndpoint: oauthHost + '/tokeninfo',
       credentialsDir: 'integration-test/data/credentials',
-      grantType: PASSWORD_CREDENTIALS_GRANT
+      grantType: OAuthGrantType.PASSWORD_CREDENTIALS_GRANT
     };
   });
 

--- a/package.json
+++ b/package.json
@@ -118,6 +118,11 @@
     {
       "name": "Matthias Achatz",
       "email": "matthias.achatz@zalando.de"
+    },
+    {
+      "name": "André Waltert",
+      "email": "andre.waltert@zalando.de",
+      "url": "https://github.com/awaltert"
     }
   ]
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,0 @@
-export const AUTHORIZATION_CODE_GRANT = 'authorization_code';
-export const PASSWORD_CREDENTIALS_GRANT = 'password';
-export const REFRESH_TOKEN_GRANT = 'refresh_token';
-export const CLIENT_CREDENTIALS_GRANT = 'client_credentials';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 export * from './oauth-tooling';
 export * from './express-tooling';
 export * from './TokenCache';
-export * from './constants';
 export * from './mock-tooling/index';
 export {
   Logger,

--- a/src/oauth-tooling.ts
+++ b/src/oauth-tooling.ts
@@ -169,7 +169,7 @@ function getTokenInfo(tokenInfoUrl: string, accessToken: string): Promise<Token>
  *  - accessTokenEndpoint string
  *  - scopes string[] optional
  *  - queryParams {} optional
- *  - redirect_uri string optional (required with AUTHORIZATION_CODE_GRANT)
+ *  - redirectUri string optional (required with AUTHORIZATION_CODE_GRANT)
  *  - code string optional (required with AUTHORIZATION_CODE_GRANT)
  *  - refreshToken string optional (required with REFRESH_TOKEN_GRANT)
  *

--- a/src/oauth-tooling.ts
+++ b/src/oauth-tooling.ts
@@ -9,15 +9,11 @@ import {
   validateOAuthConfig
 } from './utils';
 
-import {
-  AUTHORIZATION_CODE_GRANT,
-  PASSWORD_CREDENTIALS_GRANT,
-  REFRESH_TOKEN_GRANT,
-  CLIENT_CREDENTIALS_GRANT
-} from './constants';
-
 import { OAuthConfig } from './types/OAuthConfig';
-import { Token } from './types';
+import {
+  Token,
+  OAuthGrantType
+} from './types';
 import { BodyParameters } from './types/BodyParameters';
 
 const USER_JSON = 'user.json';
@@ -187,7 +183,7 @@ function getAccessToken(options: OAuthConfig): Promise<Token> {
   const credentialsPromises = [getFileData(options.credentialsDir, CLIENT_JSON)];
 
   // For PASSWORD_CREDENTIALS_GRANT wen need user credentials as well
-  if (options.grantType === PASSWORD_CREDENTIALS_GRANT) {
+  if (options.grantType === OAuthGrantType.PASSWORD_CREDENTIALS_GRANT) {
     credentialsPromises.push(getFileData(options.credentialsDir, USER_JSON));
   }
 
@@ -198,24 +194,24 @@ function getAccessToken(options: OAuthConfig): Promise<Token> {
 
     let bodyParameters: BodyParameters;
 
-    if (options.grantType === PASSWORD_CREDENTIALS_GRANT) {
+    if (options.grantType === OAuthGrantType.PASSWORD_CREDENTIALS_GRANT) {
       const userData = JSON.parse(credentials[1]);
       bodyParameters = {
         'grant_type': options.grantType,
         'username': userData.application_username,
         'password': userData.application_password
       };
-    } else if (options.grantType === CLIENT_CREDENTIALS_GRANT) {
+    } else if (options.grantType === OAuthGrantType.CLIENT_CREDENTIALS_GRANT) {
       bodyParameters = {
         'grant_type': options.grantType
       };
-    }  else if (options.grantType === AUTHORIZATION_CODE_GRANT) {
+    }  else if (options.grantType === OAuthGrantType.AUTHORIZATION_CODE_GRANT) {
       bodyParameters = {
         'grant_type': options.grantType,
         'code': options.code,
         'redirect_uri': options.redirectUri
       };
-    } else if (options.grantType === REFRESH_TOKEN_GRANT) {
+    } else if (options.grantType === OAuthGrantType.REFRESH_TOKEN_GRANT) {
       bodyParameters = {
         'grant_type': options.grantType,
         'refresh_token': options.refreshToken

--- a/src/types/OAuthConfig.ts
+++ b/src/types/OAuthConfig.ts
@@ -1,20 +1,50 @@
-type OAuthConfig = {
-  credentialsDir: string;
-  grantType: string; // (`AUTHORIZATION_CODE_GRANT` | `PASSWORD_CREDENTIALS_GRANT`)
-  accessTokenEndpoint: string;
-  scopes?: string[];
-  redirect_uri?: string; // (required with `AUTHORIZATION_CODE_GRANT`)
-  code?: string; // (required with `AUTHORIZATION_CODE_GRANT`)
-  redirectUri?: string;
-  refreshToken?: string;
-  queryParams?: {};
+import { OAuthGrantType } from '../types';
+
+type GrantConfigBase = {
+  credentialsDir: string; // according to validateOAuthConfig
+  accessTokenEndpoint: string; // according to validateOAuthConfig
+  queryParams?: { [index: string]: string };
 };
+
+type ClientCredentialsGrantConfig = GrantConfigBase & {
+  grantType: OAuthGrantType.CLIENT_CREDENTIALS_GRANT;
+  scopes: string[];
+};
+
+type AuthorizationCodeGrantConfig = GrantConfigBase & {
+  grantType: OAuthGrantType.AUTHORIZATION_CODE_GRANT;
+  code: string; // according to validateOAuthConfig
+  redirectUri: string; // according to validateOAuthConfig
+  scopes: string[];
+};
+
+type PasswordCredentialsGrantConfig = GrantConfigBase & {
+  grantType: OAuthGrantType.PASSWORD_CREDENTIALS_GRANT;
+  scopes?: string[];
+};
+
+type RefreshGrantConfig = GrantConfigBase & {
+  grantType: OAuthGrantType.REFRESH_TOKEN_GRANT;
+  refreshToken: string; // according to validateOAuthConfig
+  scopes: string[];
+};
+
+type OAuthConfig =
+  ClientCredentialsGrantConfig   |
+  AuthorizationCodeGrantConfig   |
+  PasswordCredentialsGrantConfig |
+  RefreshGrantConfig;
 
 type TokenCacheOAuthConfig = OAuthConfig & {
   tokenInfoEndpoint: string; // mandatory for TokenCache
 };
 
 export {
+  GrantConfigBase,
+  ClientCredentialsGrantConfig,
+  AuthorizationCodeGrantConfig,
+  PasswordCredentialsGrantConfig,
+  RefreshGrantConfig,
   OAuthConfig,
   TokenCacheOAuthConfig
 };

--- a/src/types/OAuthConfig.ts
+++ b/src/types/OAuthConfig.ts
@@ -1,8 +1,8 @@
 import { OAuthGrantType } from '../types';
 
 type GrantConfigBase = {
-  credentialsDir: string; // according to validateOAuthConfig
-  accessTokenEndpoint: string; // according to validateOAuthConfig
+  credentialsDir: string;
+  accessTokenEndpoint: string;
   queryParams?: { [index: string]: string };
 };
 
@@ -13,8 +13,8 @@ type ClientCredentialsGrantConfig = GrantConfigBase & {
 
 type AuthorizationCodeGrantConfig = GrantConfigBase & {
   grantType: OAuthGrantType.AUTHORIZATION_CODE_GRANT;
-  code: string; // according to validateOAuthConfig
-  redirectUri: string; // according to validateOAuthConfig
+  code: string;
+  redirectUri: string;
   scopes: string[];
 };
 
@@ -25,7 +25,7 @@ type PasswordCredentialsGrantConfig = GrantConfigBase & {
 
 type RefreshGrantConfig = GrantConfigBase & {
   grantType: OAuthGrantType.REFRESH_TOKEN_GRANT;
-  refreshToken: string; // according to validateOAuthConfig
+  refreshToken: string;
   scopes: string[];
 };
 

--- a/src/types/OAuthGrantType.ts
+++ b/src/types/OAuthGrantType.ts
@@ -1,0 +1,6 @@
+export enum OAuthGrantType {
+  AUTHORIZATION_CODE_GRANT = 'authorization_code',
+  PASSWORD_CREDENTIALS_GRANT = 'password',
+  REFRESH_TOKEN_GRANT = 'refresh_token',
+  CLIENT_CREDENTIALS_GRANT = 'client_credentials'
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,3 +7,4 @@ export * from './TokenCacheConfig';
 export * from './Token';
 export * from './Logger';
 export * from './Precedence';
+export * from './OAuthGrantType';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,12 +4,9 @@ import * as btoa from 'btoa';
 import { Request, Response } from 'express';
 
 import {
-  AUTHORIZATION_CODE_GRANT,
-  REFRESH_TOKEN_GRANT
-} from './constants';
-import {
    OAuthConfig,
-   Token
+   Token,
+   OAuthGrantType
 } from './types';
 
 const fsReadFile = (fileName: string, encoding = 'utf8'): Promise<string> => {
@@ -154,15 +151,15 @@ const validateOAuthConfig = (options: OAuthConfig): void => {
     throw TypeError('grantType must be defined');
   }
 
-  if (options.grantType === AUTHORIZATION_CODE_GRANT && !options.code) {
+  if (options.grantType === OAuthGrantType.AUTHORIZATION_CODE_GRANT && !options.code) {
     throw TypeError('code must be defined');
   }
 
-  if (options.grantType === AUTHORIZATION_CODE_GRANT && !options.redirectUri) {
+  if (options.grantType === OAuthGrantType.AUTHORIZATION_CODE_GRANT && !options.redirectUri) {
     throw TypeError('redirectUri must be defined');
   }
 
-  if (options.grantType === REFRESH_TOKEN_GRANT && !options.refreshToken) {
+  if (options.grantType === OAuthGrantType.REFRESH_TOKEN_GRANT && !options.refreshToken) {
     throw TypeError('refreshToken must be defined');
   }
 };

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -137,7 +137,7 @@ describe('oauth tooling', () => {
         tokenInfoEndpoint: '/tokeninfo',
         credentialsDir: '/credentials',
         grantType: OAuthGrantType.PASSWORD_CREDENTIALS_GRANT
-      });
+      } as any); // deactivate type system in order to test runtime behavior
 
       return expect(tokenCache.get('bar')).to.be.rejected;
     });

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -4,13 +4,12 @@ import * as chaiAsPromised from 'chai-as-promised';
 import {
   TokenCache,
   getAccessToken,
-  createAuthCodeRequestUri,
-  AUTHORIZATION_CODE_GRANT,
-  PASSWORD_CREDENTIALS_GRANT,
-  REFRESH_TOKEN_GRANT
+  createAuthCodeRequestUri
 } from '../../src/index';
 
-import { TokenCacheOAuthConfig } from '../../src/types';
+import {
+  OAuthGrantType
+} from '../../src/types';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -22,7 +21,7 @@ describe('oauth tooling', () => {
     const config = {
       accessTokenEndpoint: '/oauth2/access_token',
       credentialsDir: 'credentials',
-      grantType: AUTHORIZATION_CODE_GRANT,
+      grantType: OAuthGrantType.AUTHORIZATION_CODE_GRANT,
       redirectUri: '/some/redirect',
       code: 'some-code'
     };
@@ -65,7 +64,7 @@ describe('oauth tooling', () => {
     it('if refreshToken is not defined (in case of Refresh Token Grant)', () => {
       expect(getAccessToken.bind(undefined, {
         ...config,
-        grantType: REFRESH_TOKEN_GRANT
+        grantType: OAuthGrantType.REFRESH_TOKEN_GRANT
       })).to.throw(TypeError);
     });
   });
@@ -118,15 +117,14 @@ describe('oauth tooling', () => {
   describe('TokenCache', () => {
 
     it('should throw if tokenInfoEndpoint is not specified', () => {
-
       expect(() => {
         return new TokenCache({
           'foo': ['uid']
         }, {
           accessTokenEndpoint: '/access_token',
           credentialsDir: '/credentials',
-          grantType: PASSWORD_CREDENTIALS_GRANT
-        } as TokenCacheOAuthConfig);
+          grantType: OAuthGrantType.PASSWORD_CREDENTIALS_GRANT
+        } as any);
       }).to.throw(TypeError);
     });
 
@@ -138,7 +136,7 @@ describe('oauth tooling', () => {
         accessTokenEndpoint: '/access_token',
         tokenInfoEndpoint: '/tokeninfo',
         credentialsDir: '/credentials',
-        grantType: PASSWORD_CREDENTIALS_GRANT
+        grantType: OAuthGrantType.PASSWORD_CREDENTIALS_GRANT
       });
 
       return expect(tokenCache.get('bar')).to.be.rejected;


### PR DESCRIPTION
See #110 

I introduced `OAuthGrantType` as string enum, which substitutes the string constants declared in `constants.ts`. This was necessary, as I refactored OAuthConfig to be a union composed from tagged unions. Thus, the enum is used both as type and as value.

Please have a look at the changes and let me know what you think 😄 