### PR TITLE
feat(mocks): accept bearer token via header

### DIFF
--- a/integration-test/mock-tooling/index.ts
+++ b/integration-test/mock-tooling/index.ts
@@ -1,5 +1,6 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import fetch from 'node-fetch';
 
 import {
   getTokenInfo,
@@ -45,7 +46,35 @@ describe('mock tooling', () => {
       return expect(promise).to.be.rejected;
     });
 
-    it('should return the tokeninfo if token is valid', () => {
+    it('should return the tokeninfo if token is valid and passed via header', () => {
+
+      // given
+      const validAuthToken = {
+        'expires_in': 3600,
+        'scope': ['uid'],
+        'access_token': 'foo'
+      };
+      mockTokeninfoEndpoint(
+        {
+          url: tokeninfoEndpoint,
+          times: 1
+        },
+        [validAuthToken]
+      );
+
+      // when
+      const promise = fetch(tokeninfoEndpoint, {
+        headers: {
+          'Authorization': 'Bearer foo'
+        }
+      })
+        .then((response) => response.json());
+
+      // then
+      return expect(promise).to.become(validAuthToken);
+    });
+
+    it('should return the tokeninfo if token is valid and passed via query parameter', () => {
 
       // given
       const validAuthToken = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authmosphere",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "authmosphere is a library to support OAuth2 workflows in JavaScript projects.",
   "main": "./lib/src/index.js",
   "typings": "./lib/src/index.d.ts",

--- a/src/mock-tooling/index.ts
+++ b/src/mock-tooling/index.ts
@@ -8,6 +8,7 @@ import {
   MockOptions,
   Token
 } from '../types';
+import { extractAccessToken } from '../utils';
 
 let _tokens: Token[] = [];
 
@@ -56,10 +57,14 @@ const mockTokeninfoEndpoint = (options: MockOptions, tokens?: Token[]): nock.Sco
     .get(parsedUrl.path as string) // checked by parseUrlOrThrow
     .times(options.times || Number.MAX_SAFE_INTEGER)
     .query(true)
-    .reply((uri: string) => {
+    .reply(function(this: any, uri: string) {
 
       // token to validate
-      const givenToken = uri.split('=')[1];
+      const givenToken =
+        // either use token from query parameter...
+        uri.split('=')[1] ? uri.split('=')[1] :
+        // ...or from authorization header
+        this.req.headers.authorization ? extractAccessToken(this.req.headers.authorization[0]) : undefined;
 
       if (givenToken) {
 


### PR DESCRIPTION
`mockTokeninfoEndpoint` now accepts a token via the `Authorization`
header in addition to the query parameter.

close #224
