### PR TITLE
chore(ci): add github ci action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,7 +3,10 @@
 
 name: authmosphere ci build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened]
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,27 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      # build; test; linter
+      - run: npm run prepublishOnly
+      - run: npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-- "10"
-- "12"
-- "14"
-- "15"
-
-after_success: npm run coverage
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # authmosphere {🌍}
 
-[![Build Status](https://travis-ci.org/zalando-incubator/authmosphere.svg)](https://travis-ci.org/zalando-incubator/authmosphere?branch=master)
+![Build Status](https://github.com/zalando-incubator/authmosphere/workflows/authmosphere%20ci%20build/badge.svg?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/zalando-incubator/authmosphere/badge.svg?branch=master)](https://coveralls.io/github/zalando-incubator/authmosphere)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/4047d64636ff40a38208b6b84d186ebd)](https://www.codacy.com/app/Retro64/authmosphere?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=zalando-incubator/authmosphere&amp;utm_campaign=Badge_Grade)
 [![npm download](https://img.shields.io/npm/dm/authmosphere.svg?style=flat-square)](https://www.npmjs.com/package/authmosphere)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # authmosphere {🌍}
 
 ![Build Status](https://github.com/zalando-incubator/authmosphere/workflows/authmosphere%20ci%20build/badge.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/zalando-incubator/authmosphere/badge.svg?branch=master)](https://coveralls.io/github/zalando-incubator/authmosphere)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/4047d64636ff40a38208b6b84d186ebd)](https://www.codacy.com/app/Retro64/authmosphere?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=zalando-incubator/authmosphere&amp;utm_campaign=Badge_Grade)
 [![npm download](https://img.shields.io/npm/dm/authmosphere.svg?style=flat-square)](https://www.npmjs.com/package/authmosphere)
 [![npm version](https://img.shields.io/npm/v/authmosphere.svg?style=flat)](https://www.npmjs.com/package/authmosphere)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "authmosphere",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "lint": "eslint -c .eslintrc.js --ext .ts ./src/ ./test/",
     "lint:fix": "eslint --fix -c .eslintrc.js --ext .ts ./src/ ./test/",
     "build": "rm -rf lib && tsc",
-    "prepublishOnly": "npm run build && npm run test && npm run lint"
+    "prepublishOnly": "npm run build && npm run test && npm run lint",
+    "gh-ci-action": "npm run test && npm run lint"
   },
   "repository": {
     "type": "git",

--- a/yam2.yaml
+++ b/yam2.yaml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: authmosphere ci build
+name: Node.js CI
 
 on: [push, pull_request]
 
@@ -23,4 +23,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       # build; test; linter
-      - run: npm run gh-ci-action
+      - run: npm run prepublishOnly
+      - run: npm run coverage

--- a/yaml1.yaml
+++ b/yaml1.yaml
@@ -1,0 +1,47 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
In order to deprecate CI builds on travis, this PR configures a github action to run: build, test and linter
on node: [10.x, 12.x, 14.x, 15.x]

close #257 
